### PR TITLE
Modified crc32.h to allow it to be compiled on the latest toolchain

### DIFF
--- a/crc32.h
+++ b/crc32.h
@@ -42,7 +42,7 @@
 
 #include <avr/pgmspace.h>
 
-static const prog_uint32_t crc32_tab[] PROGMEM = {
+const prog_uint32_t crc32_tab[] PROGMEM = {
   0x00000000, 0x77073096, 0xee0e612c, 0x990951ba, 0x076dc419, 0x706af48f,
   0xe963a535, 0x9e6495a3, 0x0edb8832, 0x79dcb8a4, 0xe0d5e91e, 0x97d2d988,
   0x09b64c2b, 0x7eb17cbd, 0xe7b82d07, 0x90bf1d91, 0x1db71064, 0x6ab020f2,


### PR DESCRIPTION
I needed to modify this (declaration from static const to const) to allow my Grids firmware to compile on the latest AVR toolchain. Unclear if this would break things on earlier versions.

- tommy